### PR TITLE
Fix incorrect target language handling in translation array

### DIFF
--- a/app/Services/AutoTranslationService.php
+++ b/app/Services/AutoTranslationService.php
@@ -185,19 +185,26 @@ class AutoTranslationService
     
     /**
      * Генерирует переводы для массива ключей и значений
+     *
+     * @param array $data
+     * @param string $targetLanguage Целевой язык
+     * @param string $sourceLanguage Исходный язык
+     * @param string $contentType
+     * @param int|null $contentId
+     * @return array
      */
-    public function translateArray(array $data, $sourceLanguage = 'kz', $contentType = 'general', $contentId = null)
+    public function translateArray(array $data, $targetLanguage, $sourceLanguage = 'kz', $contentType = 'general', $contentId = null)
     {
         $results = [];
-        
+
         foreach ($data as $key => $value) {
             if (is_string($value) && !empty(trim($value))) {
-                $results[$key] = $this->translateText($value, $sourceLanguage);
+                $results[$key] = $this->translateText($value, $targetLanguage, $sourceLanguage);
             } else {
                 $results[$key] = $value;
             }
         }
-        
+
         return $results;
     }
     

--- a/tests/Unit/AutoTranslationServiceTest.php
+++ b/tests/Unit/AutoTranslationServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Services\AutoTranslationService;
+
+it('translates array using provided target and source languages', function () {
+    $service = new class extends AutoTranslationService {
+        public array $calls = [];
+
+        public function __construct() {}
+
+        public function translateText($text, $targetLanguage, $sourceLanguage = 'kz')
+        {
+            $this->calls[] = [$text, $targetLanguage, $sourceLanguage];
+            return "{$text}_{$targetLanguage}_{$sourceLanguage}";
+        }
+    };
+
+    $result = $service->translateArray(['greeting' => 'hello'], 'ru', 'en');
+
+    expect($service->calls)->toBe([
+        ['hello', 'ru', 'en'],
+    ])->and($result['greeting'])->toBe('hello_ru_en');
+});
+


### PR DESCRIPTION
## Summary
- fix `AutoTranslationService::translateArray` to accept explicit target language and pass it correctly
- add unit test for translateArray language parameters

## Testing
- `php vendor/bin/pest tests/Unit/AutoTranslationServiceTest.php`
- `php vendor/bin/pest` *(fails: Database file at path [/workspace/nrchd.kz/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6368cb00832780233dec351dcf36